### PR TITLE
v1.1

### DIFF
--- a/BareServerV1.1.md
+++ b/BareServerV1.1.md
@@ -71,8 +71,6 @@ Sec-WebSocket-Protocol: bare
 
 Sec-WebSocket-Protocol: The first value in the list of protocols the client sent.
 
-All headers that aren't listed above are irrelevant. The WebSocket class in browsers can't access response headers.
-
 Response Body:
 
 The response is a stream, forwading bytes from the remote to the client. Once either the remote or client close, the remote and client will close.

--- a/BareServerV1.1.md
+++ b/BareServerV1.1.md
@@ -1,0 +1,117 @@
+# Bare Server V1 Endpoints
+
+All endpoints are prefixed with `/v{version}/`
+
+The endpoint `/` on V1.1 would be `/v1.1/`
+
+## Request the server to fetch a URL from the remote.
+
+Refer to [version 1 `/`](https://github.com/tomphttp/specifications/blob/master/BareServerV1.md#request-the-server-to-fetch-a-url-from-the-remote).
+
+## Request a new WebSocket ID.
+
+Request headers are almost identical to `/` with the exception of protocol.
+
+| Method | Endpoint     |
+| ------ | ------------ |
+| `GET`  | /ws-new-meta |
+
+Request Headers:
+
+```
+X-Bare-Host: example.org
+X-Bare-Port: 80
+X-Bare-Protocol: ws:
+X-Bare-Path: /websocket
+X-Bare-Headers: {"Host":"example.org","Upgrade":"WebSocket","Origin":"http://example.org","Connection":"upgrade"}
+X-Bare-Forward-Headers: ["accept-encoding","accept-language","sec-websocket-extensions","sec-websocket-key","sec-websocket-version"]
+```
+
+All `X-Bare-` headers are required. Not specifying a header will result in a 400 status code. All headers are not tampered with, whatever is specified will go directly to the destination.
+
+- X-Bare-Host: The host of the destination WITHOUT the port. This would be equivalent to `URL.hostname` in JavaScript.
+- X-Bare-Port: The port of the destination. This must be a valid number. This is not `URL.port`, rather the client needs to determine what port a URL goes to. An example of logic done a the client: the protocol `http:` will go to port 80 if no port is specified in the URL.
+- X-Bare-Protocol: The protocol of the destination. V1,1 Bare Servers support `ws:` and `wss:`. If the protocol is not either, this will result in a 400 status code.
+- X-Bare-Path: The path of the destination. Be careful when specifying a path without `/` at the start. This may result in an error from the remote.
+- X-Bare-Headers: A JSON-serialized object containing request headers. Request header names may be capitalized. When making the request to the remote, capitalization is kept. Consider the header capitalization on `HTTP/1.0` and `HTTP/1.1`. Sites such as Discord check for header capitalization to make sure the client is a web browser.
+- X-Bare-Forward-Headers: A JSON-serialized array containing names of case-insensitive request headers to forward to the remote. For example, if the client's useragent automatically specified the `Accept` header and the client can't retrieve this header, it will set X-Bare-Forwarded-Headers to `["accept"]`. The Bare Server will read the `accept` header from the request headers (not X-Bare-Headers`) and add it to the headers sent to the remote. The server will automatically forward the following headers: Content-Encoding, Content-Length, Transfer-Encoding
+
+Response Headers:
+
+```
+Content-Type: text/plain
+```
+
+Response Body:
+
+The response is a unique sequence of hex encoded bytes. This should be stored until the WebSocket is open.
+
+```
+ABDCFE009023
+```
+
+## Request the server to create a WebSocket tunnel to the remote.
+
+| Method | Endpoint  |
+| ------ | --------- |
+| `GET`  | /         |
+
+Request Headers:
+
+```
+Upgrade: websocket
+Sec-WebSocket-Protocol: bare
+```
+
+Response Headers:
+
+```
+Sec-WebSocket-Protocol: bare
+```
+
+Sec-WebSocket-Protocol: The first value in the list of protocols the client sent.
+
+All headers that aren't listed above are irrelevant. The WebSocket class in browsers can't access response headers.
+
+Response Body:
+
+The response is a stream, forwading bytes from the remote to the client. Once either the remote or client close, the remote and client will close.
+
+## Request the metadata for a specific WebSocket
+
+| Method | Endpoint |
+| ------ | -------- |
+| `GET`  | /ws-meta |
+
+Request Headers:
+
+```
+X-Bare-ID: UniqueID_123
+```
+
+- X-Bare-ID: The unique ID returned by the server in the pre-request.
+
+> ⚠ All WebSocket metadata is cleared 30 seconds after the connection was established.
+
+An expired or invalid X-Bare-ID will result in a 400 status code.
+
+Response Headers:
+
+```
+Content-Type: application/json
+```
+
+Response Body:
+
+```json
+{
+	"headers": {
+		"Set-Cookie": [
+			"Cookie",
+			"Cookie"
+		],
+		"Sec-WebSocket-Accept": "original_websocket_protocol",
+		"Sec-WebSocket-Extensions": "original_websocket_extensions"
+	}
+}
+```


### PR DESCRIPTION
Making `/ws-new-meta` use the same `X-Bare-` headers as `/` allows for unifying how the destination is set. Not only will this remove the need for WebSocket protocol encoding, but it will allow the Bare Server to catch errors such as missing or invalid headers and report them to the client by responding with a non-20x status code.

## How clients will implement this

Clients will be forced to remove the simple-limiting hook on global.WebSocket
```js
WebSocket = new Proxy(WebSocket, {
    construct: (target, [ url, protocol ]) => {
        return Reflect.construct(target, [ bareServerWS, bareServerWSProtocol(url, protocol) ]);
    },
});
```

Instead of this hook, I propose a new solution: **Wrap the WebSocket class**
```js
const bareServerWS = 'ws://127.0.0.1/bare/';
const bareServerWSMeta = 'http://127.0.0.1/bare/ws-meta';
const bareServerWSNewMeta = 'http://127.0.0.1/bare/ws-new-meta';
const pageOrigin = 'http://example.org';
const OriginalWebSocket = window.WebSocket;
const originalFetch = window.fetch;

// TODO: call ProxyWebSocket{}.onopen,onclose,onerror,onmessage when event is dispatched

class ProxyWebSocket extends EventTarget {
	#socket;
	#id;
	#socketPromise;
	#bufferedAmount = 0;
	#protocol = '';
	#extensions = '';
	#binaryType = '';
	// simulate WebSocket.prototype.protocol
	get protocol(){
		return this.#protocol;
	}
	get extensions(){
		return this.#extensions;
	}
	constructor(url, protocols){
		super(); // EventTarget

		// async called from sync function
		this.#socketPromise = this.#createWebSocket(url, protocols);
	}
	#forwardEvents(){
		this.#socket.addEventListener('open', async () => {
			const outgoingMeta = await originalFetch(bareServerWSMeta);
			const meta = await outgoingMeta.json();

			this.#loadMeta(meta);
			// dispatch once meta is loaded
			this.dispatchEvent(new Event('open'));
		});
		
		this.#socket.addEventListener('error', event => {
			this.dispatchEvent(new ErrorEvent('error', event));
		});

		this.#socket.addEventListener('close', event => {
			this.dispatchEvent(new Event('close', event));
		});

		this.#socket.addEventListener('message', event => {
			this.dispatchEvent(new MessageEvent('message', event));
		});
	}
	close(code){
		if(this.#socket){
			this.#socket.close(code);
		}else{
			throw new Error('Socket not ready');
		}
	}
	send(data){
		if(this.#socket){
			this.#socket.send(data);
		}else{
			throw new Error('Socket not ready');
		}
	}
	get bufferedAmount(){
		if(this.#socket){
			return this.#socket.bufferedAmount;
		}else{
			return this.#bufferedAmount;
		}
	}
	get binaryType(){
		if(this.#socket){
			return this.#socket.binaryType;
		}else{
			return this.#binaryType;
		}
	}
	set binaryType(value){
		this.#socketPromise.then(() => {
			this.#socket.binaryType = value;
		});

		return value;
	}
	#loadMeta(meta){
		const parsedHeaders = new Headers(meta.headers);

		if(parsedHeaders.has('sec-websocket-protocol')){
			this.#protocol = parsedHeaders.get('sec-websocket-protocol');
		}
		
		if(parsedHeaders.has('sec-websocket-extensions')){
			this.#extensions = parsedHeaders.get('sec-websocket-extensions');
		}
	}
	#getPort(port, protocol){
		if(port === ''){
			switch(protocol){
				case'ws:':
					return '80';
					break;
				case'wss:':
					return '443';
					break;
			}
		}else{
			return port;
		}
	}
	#getHeaders(url, protocols){
		const parsedURL = new URL(url);
		const headers = new Headers();
		
		headers.set('X-Bare-Host', parsedURL.hostname);
		headers.set('X-Bare-Port', this.#getPort(parsedURL.port, parsedURL.protocol));
		headers.set('X-Bare-Path', parsedURL.pathname + parsedURL.search);
		
		const remoteHeaders = {};

		remoteHeaders['Host'] = parsedURL.hostname;
		remoteHeaders['Origin'] = pageOrigin;
		remoteHeaders['Pragma'] = 'no-cache';
		remoteHeaders['Cache-Control'] = 'no-cache';
		remoteHeaders['Upgrade'] = 'websocket';
		remoteHeaders['User-Agent'] = navigator.userAgent;
		remoteHeaders['Connection'] = 'Upgrade';

		if(typeof protocols === 'string'){
			remoteHeaders['Sec-Websocket-Protocol'] = protocols;
		}else if(Array.isArray(protocols)){
			remoteHeaders['Sec-Websocket-Protocol'] = protocol.join(', ');
		}

		/*
		let cookies = this.#getCookies(url);
		if(cookies.length > 0){
			remoteHeaders['Cookie'] = cookies.join('; ');
		}
		*/

		const forwardHeaders = [
			'accept-encoding',
			'accept-language',
			'sec-websocket-extensions',
			'sec-websocket-key',
			'sec-websocket-version',
		];

		headers.set('X-Bare-Headers', JSON.stringify(remoteHeaders));
		headers.set('X-Bare-Forward-Headers', JSON.stringify(forwardHeaders));
		
		return headers;
	}
	async #createWebSocket(url, protocols){
		const idOutgoing = await originalFetch(bareServerWSNewMeta, {
			headers: this.#getHeaders(url, protocols),
		});

		this.#id = await idOutgoing.text();

		this.#socket = new OriginalWebSocket(bareServerWS);

		this.#forwardEvents();
	}
};

window.WebSocket = ProxyWebSocket;
```