### PR TITLE
Eliminate redundancy and extend header value lengths in CHE

### DIFF
--- a/BareServerV3.md
+++ b/BareServerV3.md
@@ -55,7 +55,7 @@ Example:
 X-Bare-Port: 80
 X-Bare-Protocol: http:
 X-Bare-Path: /index.php
-X-Bare-Headers: ;#Host+ example.org%Accept=!text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+X-Bare-Headers: ;#Host5example.org%Accept#\text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
 ```
 
 - X-Bare-Port: The port of the destination. This must be a valid number and cannot be empty. An example of logic the client must do is: `const port = protocol == "http:" ? 80 : 443;`
@@ -75,7 +75,7 @@ Content-Encoding: ...
 Content-Length: ...
 X-Bare-Status: 200
 X-Bare-Status-text: OK
-X-Bare-Headers: ;+Content-Type) text/html
+X-Bare-Headers: ;+Content-Type1text/html
 ```
 
 - Content-Encoding: The remote body's content encoding.

--- a/compact-header-encoding/tests.mjs
+++ b/compact-header-encoding/tests.mjs
@@ -18,6 +18,15 @@ ensureUnchanged([
     [42, "69"]
 ])
 
+ensureUnchanged([
+    ["Host", "example.org"],
+    ["Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"]
+])
+
+ensureUnchanged([
+    ["Content-Type", "text/html"],
+])
+
 let i = 0
 let error
 for (;;) {

--- a/compact-header-encoding/tests.mjs
+++ b/compact-header-encoding/tests.mjs
@@ -31,6 +31,6 @@ for (;;) {
 }
 
 equal(error.message, "Header value length exceeds maximum length", error)
-equal(i, 4465, "Error was thrown on an unexpected header value length")
+equal(i, 212110 + 1, "Error was thrown on an unexpected header value length")
 
 // TODO: More tests


### PR DESCRIPTION
Header value lengths are now much smarter! However, they are a bit more complicated. The "next/continue/tag" bit is stored in the second bit, as CHE_BYTE_RANGE's LSB is zero, which in turn means a bit flip would make the result invalid. Moreover, the lengths can take up one, two, or three bytes, and each case has somewhat different behavior. Lastly, redundancy is eliminated by removing duplicates due to extra zero digits. For example, 0 and 00 refer to the same value in base ten; however, one can make 00 equal ten plus one plus zero, which would be eleven. This is not a novel trick, but it does make better use of the second/third bytes.