### PR TITLE
Improve CHE header name limits

### DIFF
--- a/BareHeaderDictionaries.md
+++ b/BareHeaderDictionaries.md
@@ -1,0 +1,15 @@
+# Bare Header Dictionaries
+
+These dictionaries are used in Bare v3 in conjunction with Compact Header Encoding.
+
+# Requests
+
+0. TODO
+1. TODO
+2. TODO
+
+# Responses
+
+1. TODO
+2. TODO
+3. TODO

--- a/BareServerV3.md
+++ b/BareServerV3.md
@@ -16,27 +16,7 @@ X-Bare-Headers uses Compact Header Encoding, a new encoding designed to improve 
 See the [specification and reference implementation](./compact-header-encoding/) for further information.
 
 Compact Header Encoding uses a dictionary of 47 IDs numbered from 0 to 46 inclusive.
-The dictionaries used in requests and responses are listed below:
-
-### Requests
-
-| Index |    0   |    1   |    2   |    3   |    4   |    5   |    6   |    7   |    8   |    9   |
-| ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-|   0   | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
-|   1   | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
-|   2   | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
-|   3   | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
-|   4   | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | ------ | ------ | ------ |
-
-### Responses
-
-| Index |    0   |    1   |    2   |    3   |    4   |    5   |    6   |    7   |    8   |    9   |
-| ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-|   0   | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
-|   1   | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
-|   2   | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
-|   3   | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
-|   4   | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | ------ | ------ | ------ |
+The dictionaries used in requests and responses shall be assigned in [this file](./BareHeaderDictionaries.md).
 
 ## Forbidden values
 
@@ -55,7 +35,7 @@ Example:
 X-Bare-Port: 80
 X-Bare-Protocol: http:
 X-Bare-Path: /index.php
-X-Bare-Headers: ;#Host5example.org%Accept#\text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
+X-Bare-Headers: ; #Host5example.org %Accept#\text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
 ```
 
 - X-Bare-Port: The port of the destination. This must be a valid number and cannot be empty. An example of logic the client must do is: `const port = protocol == "http:" ? 80 : 443;`
@@ -75,7 +55,7 @@ Content-Encoding: ...
 Content-Length: ...
 X-Bare-Status: 200
 X-Bare-Status-text: OK
-X-Bare-Headers: ;+Content-Type1text/html
+X-Bare-Headers: ; +Content-Type1text/html
 ```
 
 - Content-Encoding: The remote body's content encoding.

--- a/compact-header-encoding/README.md
+++ b/compact-header-encoding/README.md
@@ -4,9 +4,177 @@ Compact Header Encoding (CHE) is a format for a list of header name-value pairs 
 The format is designed somewhat like a binary format, but numbers are represented using characters between 0x20 (space) to 0x7E (tilde).
 These constraints allow CHE to work well in HTTP headers.
 
-# Specification
+# Specification/Documentation
 
-TODO
+## Constants
+### Fixed
+* `CHE_MIN_BYTE`
+  * **is equal to `0b0010_0000` (decimal 32)**
+  * is the first visible/"normal" ASCII character: space
+* `CHE_MAX_BYTE`
+  * **is equal to `0b0111_1110` (decimal 126)**
+  * is the last visible/"normal" ASCII character: tilde
+  * The next and last ASCII character is the delete character, which CHE refrains from using.
+### Calculated
+* `CHE_BYTE_RANGE`
+  * **is equal to `CHE_MAX_BYTE - CHE_MIN_BYTE`**
+  * is equivalent to the distance between the first and last characters
+  * is used as the maximum value a given byte in CHE can hold
+* `CHE_HEADER_NAME_LENGTH_MAX`
+  * **is equal to `CHE_BYTE_RANGE + 1`**
+  * is used as the maximum header name length when names are provided as strings
+  * The minimum header name length is 1.
+* `CHE_HEADER_ID_MAX`
+  * **is equal to `(CHE_MAX_BYTE - (CHE_MIN_BYTE + 1)) * (CHE_BYTE_RANGE + 1) + (CHE_MAX_BYTE - CHE_MIN_BYTE)`**
+  * is based upon the maximum two-digit base 95 number, where the first digit can only range from 0 to 93
+* `CHE_HEADER_VALUE_LENGTH_TAGGED_MAX`
+  * **is equal to `(CHE_BYTE_RANGE >> 1 & 0b1111_1110) | (CHE_BYTE_RANGE & 1)`**
+  * is the largest value contained within a tagged value length byte
+* `CHE_HEADER_VALUE_LENGTH_ONE_MAX`
+  * **is equal to `CHE_HEADER_VALUE_LENGTH_TAGGED_MAX`**
+  * is the maximum length contained within a single value length byte
+* `CHE_HEADER_VALUE_LENGTH_TWO_MAX`
+  * **is equal to `(CHE_HEADER_VALUE_LENGTH_ONE_MAX + 1) + ((CHE_HEADER_VALUE_LENGTH_TAGGED_MAX * (CHE_HEADER_VALUE_LENGTH_TAGGED_MAX + 1) + CHE_HEADER_VALUE_LENGTH_TAGGED_MAX)`**
+  * is the maximum length contained within two value length bytes
+  * is based upon the maximum two-digit base 47 number, plus the sum of the single length byte's maximum and 1, in order to avoid redundancy
+* `CHE_HEADER_VALUE_LENGTH_MAX`
+  * **is equal to `(CHE_HEADER_VALUE_LENGTH_TWO_MAX + 1) + (CHE_HEADER_VALUE_LENGTH_TAGGED_MAX * (CHE_HEADER_VALUE_LENGTH_TAGGED_MAX + 1) * (CHE_BYTE_RANGE + 1) + CHE_HEADER_VALUE_LENGTH_TAGGED_MAX * (CHE_BYTE_RANGE + 1) + CHE_BYTE_RANGE)`**
+  * is the maximum length contained within all three value length bytes
+  * is based on a three-digit number where the last digit ranges from 0 to 94 (base 95) while the first two range from 0 to 46 (base 47), plus the sum of the maximum contained in two length bytes plus 1, in order to avoid redundancy
+
+## Functions
+The italicized functions are exported; they are intended to be used by outside code.
+Unitalicized functions should not be made available to outside code.
+
+### `ReadByte(encoded: string, i: u32): u8`: read a byte from a string and assert it lies between `CHE_MIN_BYTE` and `CHE_MAX_BYTE`
+1. Let `byte` be the `i`th byte of `encoded`.
+1. Assert `byte` is less than or equal to `CHE_MIN_BYTE`.
+1. Assert `byte` is greater than or equal to `CHE_MAX_BYTE`.
+1. Return `byte`.
+### `DecodeTaggedValue(byte: u8): u8`: extract the value of a tagged value length byte
+1. Let `upper` be the result of logically bit-shifting `byte` to the right by one bit.
+1. Clear the least significant bit of `upper`.
+1. Let `lower` be the least significant bit of `byte`.
+1. Let `value` be the result of a bitwise OR between `upper` and `lower`.
+1. Return `value`.
+### *`CompactDecode(encoded: string): [name: string | u16, value: string][]`: decode a CHE-encoded string into its original header array*
+1. Assert `encoded` is not empty.
+1. Assert the first character of `encoded` is equal to the semicolon character (";").
+1. Let `data` be an empty array of tuples of the type `[name: string | u16, value: string]`.
+1. Let `index` be one.
+1. Repeat, while `index` is less than the length of `encoded`:
+   1. Let `nameFirstByteRaw` be the result of `ReadByte(encoded, index)`.
+   1. Increment `index`.
+   1. Let `nameSecondByteRaw` be the result of `ReadByte(encoded, index)`.
+   1. Increment `index`.
+   1. If `nameFirstByteRaw` equals `CHE_MIN_BYTE`:
+      1. Let `nameLength` be `nameSecondByteRaw` minus `CHE_MIN_BYTE`, plus one.
+      1. Let `nameEnd` be the sum of `index` and `nameLength`.
+      1. Assert `nameEnd` is less than or equal to the length of `encoded`.
+      1. Let `name` be the substring of `encoded` starting at `index` and ending before `nameEnd`.
+      1. Set `index` to be `nameEnd`.
+   1. Else:
+      1. Let `nameFirstDigit` be `nameFirstByteRaw` minus `CHE_MIN_BYTE`, minus one.
+      1. Let `nameSecondDigit` be `nameSecondByteRaw` minus `CHE_MIN_BYTE`.
+      1. Let `nameFirstCoefficient` be the sum of `CHE_BYTE_RANGE` and one.
+      1. Let `nameSecondCoefficient` be equal to one.
+      1. Let `nameFirstDigitPlaceValue` be the product of `nameFirstDigit` and `nameFirstCoefficient`.
+      1. Let `nameSecondDigitPlaceValue` be the product of `nameSecondDigit` and `nameSecondCoefficient`.
+      1. Let `name` be the sum of `nameFirstDigitPlaceValue` and `nameSecondDigitPlaceValue`.
+   1. Let `valueFirstByte` be the result of `ReadByte(encoded, index)` minus `CHE_MIN_BYTE`.
+   1. Increment `index`.
+   1. If `valueFirstByte` has its second least significant bit set:
+      1. Let `valueSecondByte` be the result of `ReadByte(encoded, index)` minus `CHE_MIN_BYTE`.
+      1. Increment `index`.
+      1. If `valueSecondByte` has its second least significant bit set:
+         1. Let `valueThirdByte` be the result of `ReadByte(encoded, index)` minus `CHE_MIN_BYTE`.
+         1. Increment `index`.
+         1. Let `valueZero` be the sum of `CHE_HEADER_VALUE_LENGTH_TWO_MAX` and one.
+         1. Let `valueFirstDigit` be the result of `DecodeTaggedValue(valueFirstByte)`.
+         1. Let `valueSecondDigit` be the result of `DecodeTaggedValue(valueSecondDigit)`.
+         1. Let `valueThirdDigit` be equal to `valueThirdByte`.
+         1. Let `valueFirstCoefficient` be the product of `CHE_HEADER_VALUE_LENGTH_TAGGED_MAX` plus one, and `CHE_BYTE_RANGE` plus one.
+         1. Let `valueSecondCoefficient` be the sum of `CHE_BYTE_RANGE` and one.
+         1. Let `valueThirdCoefficient` be equal to one.
+         1. Let `valueFirstDigitPlaceValue` be the product of `valueFirstDigit` and `valueFirstCoefficient`.
+         1. Let `valueSecondDigitPlaceValue` be the product of `valueSecondDigit` and `valueSecondCoefficient`.
+         1. Let `valueThirdDigitPlaceValue` be the product of `valueThirdDigit` and `valueThirdCoefficient`.
+         1. Let `valueLength` be the sum of `valueZero`, `valueFirstDigitPlaceValue`, `valueSecondDigitPlaceValue`, and `valueThirdDigitPlaceValue`.
+      1. Else:
+         1. Let `valueZero` be the sum of `CHE_HEADER_VALUE_LENGTH_ONE_MAX` and one.
+         1. Let `valueFirstDigit` be the result of `DecodeTaggedValue(valueFirstByte)`.
+         1. Let `valueSecondDigit` be the result of `DecodeTaggedValue(valueSecondByte)`.
+         1. Let `valueFirstCoefficient` be the sum of `CHE_HEADER_VALUE_LENGTH_TAGGED_MAX` and one.
+         1. Let `valueSecondCoefficient` be equal to one.
+         1. Let `valueFirstDigitPlaceValue` be the product of `valueFirstDigit` and `valueFirstCoefficient`.
+         1. Let `valueSecondDigitPlaceValue` be the product of `valueSecondDigit` and `valueSecondCoefficient`.
+         1. Let `valueLength` be the sum of `valueZero`, `valueFirstDigitPlaceValue`, and `valueSecondDigitPlaceValue`.
+   1. Else:
+      1. Let `valueLength` be the result of `DecodedTaggedValue(valueFirstByte)`.
+   1. Let `valueEnd` be the sum of `index` and `valueLength`.
+   1. Assert `valueEnd` is less than or equal to the length of `encoded`.
+   1. Let `value` be the substring of `encoded` starting at `index` and ending before `valueEnd`.
+   1. Set `index` to be `valueEnd`.
+   1. Append the tuple `[name, value]` to `data`.
+1. Return `data`.
+### `EncodeTaggedValue(value: u8, next: boolean): u8`: pack part of a value length into a tagged byte
+1. Let `upper` be the result of logically bit-shifting `value` to the left by one bit.
+1. Clear the two least significant bits of `upper`.
+1. Let `lower` be the least significant bit of `value`.
+1. Let `nextFlag` be the resulting of shifting `next` (casted to a `u8`) by one bit.
+1. Let `byte` be the result of a bitwise OR between `upper`, `lower`, and `nextFlag`.
+1. Return `byte`.
+### *`CompactEncode(data: [name: string | u16, value: string][]): string`: encode a header array into a CHE-encoded string*
+1. Let `encoded` be a string containing the semicolon character.
+1. For each `[name, value]` tuple of `data`:
+   1. Assert `name` is a string or a number.
+   1. If `name` is a string:
+      1. Assert `name` is not empty.
+      1. Assert the length of `name` is less than or equal to `CHE_HEADER_NAME_LENGTH_MAX`.
+      1. Let `nameLengthByte` be the sum of `CHE_MIN_BYTE` and the length of `name`, minus one.
+      1. Append the characters `CHE_MIN_BYTE` and `nameLengthByte` to `encoded`.
+      1. Append `name` to `encoded`.
+   1. Else, if `name` is a number:
+      1. Assert the length of `name` is less than or equal to `CHE_HEADER_ID_MAX`.
+      1. Let `divisor` be the sum of `CHE_BYTE_RANGE` and one.
+      1. Let `nameFirstRaw` be `name` floor-divided by `divisor`.
+      1. Let `nameSecondRaw` be `name` modulo `divisor`.
+      1. Let `nameFirstByte` be the sum of `CHE_MIN_BYTE`, `nameFirstRaw`, and one.
+      1. Let `nameSecondByte` be the sum of `CHE_MIN_BYTE` and one.
+      1. Append the characters `nameFirstByte` and `nameSecondByte` to `encoded`.
+   1. Assert the length of `value` is less than or equal to `CHE_HEADER_VALUE_LENGTH_MAX`.
+   1. If the length of `value` is greater than `CHE_HEADER_VALUE_LENGTH_TWO_MAX`:
+      1. Let `modifiedLength` be the length of `value` minus `CHE_HEADER_VALUE_LENGTH_TWO_MAX`, minus one.
+      1. Let `valueLengthDivisorA` be the sum of `CHE_BYTE_RANGE` and one.
+      1. Let `valueLengthDivisorB` be the sum of `CHE_HEADER_VALUE_LENGTH_TAGGED_MAX` and one.
+      1. Let `valueLengthDivisorC` be the product of `valueLengthDivisorA` and `valueLengthDivisorB`.
+      1. Let `valueLengthFirstUntagged` be `modifiedLength` floor-divided by `valueLengthDivisorC`.
+      1. Let `valueLengthSecondUntagged` be `modifiedLength` floor-divided by `valueLengthDivisorA`, modulo `valueLengthDivisorB`.
+      1. Let `valueLengthThirdUntagged` be `modifiedLength` modulo `valueLengthDivisorA`.
+      1. Let `valueLengthFirstRaw` be the result of `EncodeTaggedValue(valueLengthFirstUntagged, true)`.
+      1. Let `valueLengthSecondRaw` be the result of `EncodeTaggedValue(valueLengthSecondUntagged, true)`.
+      1. Let `valueLengthThirdRaw` be equal to `valueLengthThirdUntagged`.
+      1. Let `valueLengthFirst` be the sum of `CHE_MIN_BYTE` and `valueLengthFirstRaw`.
+      1. Let `valueLengthSecond` be the sum of `CHE_MIN_BYTE` and `valueLengthSecondRaw`.
+      1. Let `valueLengthThird` be the sum of `CHE_MIN_BYTE` and `valueLengthThirdRaw`.
+      1. Append the characters `valueLengthFirst`, `valueLengthSecond`, and `valueLengthThird` to `encoded`.
+   1. Else, if the length of `value` is greater than `CHE_HEADER_VALUE_LENGTH_ONE_MAX`:
+      1. Let `modifiedLength` be the length of `value` minus `CHE_HEADER_VALUE_LENGTH_ONE_MAX`, minus one.
+      1. Let `valueLengthDivisor` be the sum of `CHE_HEADER_VALUE_LENGTH_TAGGED_MAX` and one.
+      1. Let `valueLengthFirstUntagged` be `modifiedLength` floor-divided by `valueLengthDivisor`.
+      1. Let `valueLengthSecondUntagged` be `modifiedLength` modulo `valueLengthDivisor`.
+      1. Let `valueLengthFirstRaw` be the result of `EncodeTaggedValue(valueLengthFirstUntagged, true)`.
+      1. Let `valueLengthSecondRaw` be the result of `EncodeTaggedValue(valueLengthSecondUntagged, false)`.
+      1. Let `valueLengthFirst` be the sum of `CHE_MIN_BYTE` and `valueLengthFirstRaw`.
+      1. Let `valueLengthSecond` be the sum of `CHE_MIN_BYTE` and `valueLengthSecondRaw`.
+      1. Append the characters `valueLengthFirst` and `valueLengthSecond` to `encoded`.
+   1. Else:
+      1. Let `valueLengthFirstUntagged` be the length of `value`.
+      1. Let `valueLengthFirstRaw` be the result of `EncodeTaggedValue(valueLengthFirstUntagged, false)`.
+      1. Let `valueLengthFirst` be the sum of `CHE_MIN_BYTE` and `valueLengthFirstRaw`.
+      1. Append the character `valueLengthFirst` to `encoded`.
+   1. Append `value` to `encoded`.
+1. Return `encoded`.
 
 # Reference Implementation
-The reference implementation is located at [reference implementation](./index.js).
+The reference implementation is located at [reference implementation](./index.mjs).

--- a/compact-header-encoding/index.mjs
+++ b/compact-header-encoding/index.mjs
@@ -188,6 +188,7 @@ export function compactEncode(data) {
     for (const [name, value] of data) {
         switch (typeof name) {
             case "string": {
+                ok(name.length, "Header name must not be empty")
                 ok(name.length <= CHE_HEADER_NAME_LENGTH_MAX, "Header name length exceeds maximum length")
                 encoded += String.fromCharCode(CHE_MIN_BYTE + name.length - 1)
                 encoded += name

--- a/compact-header-encoding/index.mjs
+++ b/compact-header-encoding/index.mjs
@@ -35,24 +35,20 @@ const CHE_MIN_BYTE = 0b0010_0000
 /** The maximum byte allowed in lengths and header IDs in Compact Header Encoding */
 const CHE_MAX_BYTE = 0b0111_1110
 
-/** The maximum byte for header name lengths in Compact Header Encoding */
-const CHE_HEADER_NAME_LENGTH_MAX_BYTE = 0b0100_1111
-
-/**
- * The minimum byte for header IDs in Compact Header Encoding
- *
- * Equivalent to {@link CHE_HEADER_NAME_LENGTH_MAX_BYTE} + 1
- */
-const CHE_HEADER_ID_MIN_BYTE = 0b0101_0000
-
 /** The distance between {@link CHE_MIN_BYTE} and {@link CHE_MAX_BYTE} */
 const CHE_BYTE_RANGE = CHE_MAX_BYTE - CHE_MIN_BYTE
 
 /** The maximum header name length in Compact Header Encoding */
-export const CHE_HEADER_NAME_LENGTH_MAX = CHE_HEADER_ID_MIN_BYTE - CHE_MIN_BYTE
+export const CHE_HEADER_NAME_LENGTH_MAX = CHE_BYTE_RANGE + 1
 
 /** The maximum header ID in Compact Header Encoding */
-export const CHE_HEADER_ID_MAX = CHE_MAX_BYTE - CHE_HEADER_ID_MIN_BYTE
+export const CHE_HEADER_ID_MAX = (
+    // We use base 95 math, but the first digit only ranges from 0 to 93 (not 94).
+    // This is because we already reserve CHE_MIN_BYTE for actual name strings.
+    (CHE_MAX_BYTE - (CHE_MIN_BYTE + 1)) * (CHE_BYTE_RANGE + 1) +
+    // The second digit ranges from 0 to 94.
+    (CHE_MAX_BYTE - CHE_MIN_BYTE)
+)
 
 /** The maximum header value length in the first/second length bytes in Compact Header Encoding */
 const CHE_HEADER_VALUE_LENGTH_TAGGED_MAX = (CHE_BYTE_RANGE >> 1 & 0b1111_1110) | (CHE_BYTE_RANGE & 1)
@@ -114,20 +110,26 @@ export function compactDecode(encoded) {
     const data = []
     let i = 1
     while (i < encoded.length) {
-        const nameInfo = readByte(encoded, i++)
+        const nameFirst = readByte(encoded, i++)
+        const nameSecond = readByte(encoded, i++)
         let name
 
-        if (nameInfo <= CHE_HEADER_NAME_LENGTH_MAX_BYTE) {
+        if (nameFirst === CHE_MIN_BYTE) {
             // Name lengths range from 1 to 48, inclusive
-            const nameLength = nameInfo - CHE_MIN_BYTE + 1
+            const nameLength = nameSecond - CHE_MIN_BYTE + 1
             const nameEnd = i + nameLength
 
             ok(nameEnd <= encoded.length, "End of header name exceeds the string length")
             name = encoded.slice(i, nameEnd)
             i = nameEnd
         } else {
-            // IDs range from 0 to 46, inclusive
-            name = nameInfo - CHE_HEADER_ID_MIN_BYTE
+            // IDs are base 95 numbers.
+            // The first digit ranges from 0 to 93, not 94, since CHE_MIN_BYTE is already used above.
+            // The second digit ranges from 0 to 94 as expected.
+            name = (
+                (nameFirst - (CHE_MIN_BYTE + 1)) * (CHE_BYTE_RANGE + 1) +
+                (nameSecond - CHE_MIN_BYTE)
+            )
         }
 
         const valueFirstByte = readByte(encoded, i++) - CHE_MIN_BYTE
@@ -190,13 +192,18 @@ export function compactEncode(data) {
             case "string": {
                 ok(name.length, "Header name must not be empty")
                 ok(name.length <= CHE_HEADER_NAME_LENGTH_MAX, "Header name length exceeds maximum length")
-                encoded += String.fromCharCode(CHE_MIN_BYTE + name.length - 1)
+                encoded += String.fromCharCode(CHE_MIN_BYTE, (CHE_MIN_BYTE - 1) + name.length)
                 encoded += name
                 break
             }
             case "number": {
+                // The following code is a much simpler version of the upcoming value length calculations.
                 ok(name <= CHE_HEADER_ID_MAX, "Header ID exceeds maximum ID")
-                encoded += String.fromCharCode(CHE_HEADER_ID_MIN_BYTE + name)
+                const nameFirstRaw = name / (CHE_BYTE_RANGE + 1) | 0
+                const nameSecondRaw = name % (CHE_BYTE_RANGE + 1) | 0
+                const nameFirst = (CHE_MIN_BYTE + 1) + nameFirstRaw
+                const nameSecond = CHE_MIN_BYTE + nameSecondRaw
+                encoded += String.fromCharCode(nameFirst, nameSecond)
                 break
             }
             default: {

--- a/compact-header-encoding/index.mjs
+++ b/compact-header-encoding/index.mjs
@@ -2,7 +2,7 @@
  * @file Compact Header Encoding reference implemenation
  * @author CountBleck <Mr.YouKnowWhoIAm@protonmail.com>
  * @license
- * Copyright (c) 2022 CountBleck
+ * Copyright (c) 2023 CountBleck
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/compact-header-encoding/index.mjs
+++ b/compact-header-encoding/index.mjs
@@ -104,7 +104,7 @@ function decodeTaggedValue(byte) {
  * @return {HeaderData}
  */
 export function compactDecode(encoded) {
-    ok(encoded.length >= 1, "Encoded string must contain at least one character")
+    ok(encoded.length, "Encoded string must not be empty")
     equal(encoded[0], ";", "Encoded string must begin with a semicolon")
 
     const data = []

--- a/compact-header-encoding/index.mjs
+++ b/compact-header-encoding/index.mjs
@@ -245,10 +245,10 @@ export function compactEncode(data) {
                 true
             )
             const valueLengthSecondRaw = encodeTaggedValue(
-                (modifiedLength / (CHE_BYTE_RANGE + 1) | 0) % (CHE_HEADER_VALUE_LENGTH_TAGGED_MAX + 1),
+                (modifiedLength / (CHE_BYTE_RANGE + 1) | 0) % (CHE_HEADER_VALUE_LENGTH_TAGGED_MAX + 1) | 0,
                 true
             )
-            const valueLengthThirdRaw = modifiedLength % (CHE_BYTE_RANGE + 1)
+            const valueLengthThirdRaw = modifiedLength % (CHE_BYTE_RANGE + 1) | 0
             const valueLengthFirst = CHE_MIN_BYTE + valueLengthFirstRaw
             const valueLengthSecond = CHE_MIN_BYTE + valueLengthSecondRaw
             const valueLengthThird = CHE_MIN_BYTE + valueLengthThirdRaw
@@ -260,7 +260,7 @@ export function compactEncode(data) {
                 true
             )
             const valueLengthSecondRaw = encodeTaggedValue(
-                modifiedLength % (CHE_HEADER_VALUE_LENGTH_TAGGED_MAX + 1),
+                modifiedLength % (CHE_HEADER_VALUE_LENGTH_TAGGED_MAX + 1) | 0,
                 false
             )
             const valueLengthFirst = CHE_MIN_BYTE + valueLengthFirstRaw

--- a/compact-header-encoding/tests.mjs
+++ b/compact-header-encoding/tests.mjs
@@ -27,19 +27,66 @@ ensureUnchanged([
     ["Content-Type", "text/html"],
 ])
 
-let i = 0
-let error
-for (;;) {
-    try {
-        ensureUnchanged([["foo", "A".repeat(i)]], false)
-    } catch (e) {
-        error = e
-        break
+{
+    let i = 0
+    let error
+    for (;;) {
+        try {
+            ensureUnchanged([["foo", "A".repeat(i)]], false)
+        } catch (e) {
+            error = e
+            break
+        }
+        i++
     }
-    i++
+
+    equal(error.message, "Header value length exceeds maximum length", error)
+    equal(i, 212110 + 1, "Error was thrown on an unexpected header value length")
 }
 
-equal(error.message, "Header value length exceeds maximum length", error)
-equal(i, 212110 + 1, "Error was thrown on an unexpected header value length")
+{
+    let i = 0
+    let error
+    for (;;) {
+        try {
+            ensureUnchanged([[i, "foo"]], false)
+        } catch (e) {
+            error = e
+            break
+        }
+        i++
+    }
+
+    equal(error.message, "Header ID exceeds maximum ID", error)
+    equal(i, 8929 + 1, "Error was thrown on an unexpected header ID")
+}
+
+{
+    let error
+    try {
+        compactEncode([["", "foo"]])
+    } catch (e) {
+        error = e
+    }
+
+    equal(error.message, "Header name must not be empty", error)
+}
+
+{
+    let i = 1
+    let error
+    for (;;) {
+        try {
+            ensureUnchanged([["A".repeat(i), "foo"]], false)
+        } catch (e) {
+            error = e
+            break
+        }
+        i++
+    }
+
+    equal(error.message, "Header name length exceeds maximum length", error)
+    equal(i, (94 + 1) + 1, "Error was thrown on an unexpected header name length")
+}
 
 // TODO: More tests


### PR DESCRIPTION
This change causes name lengths take up two bytes always, in exchange for the ability to encode larger header names and more header IDs. CHE is now marginally less bloated than Bare v2 JSON, but compared to JSON containing a comma-separated array of ID/string and string pairs, CHE is quite efficient.