### PR TITLE
Fully specify Bare v3

### DIFF
--- a/BareServerV3.md
+++ b/BareServerV3.md
@@ -4,29 +4,13 @@ All endpoints are prefixed with `/v{version}/`
 
 The endpoint `/` on v3 would be `/v3/`
 
-## Header Lists
-
-Bare Server v3 adapts header lists.
-
-See [RFC 8941: Structured Field Values for HTTP](https://www.rfc-editor.org/rfc/rfc8941.html#section-3.1)
-
 ## Compact Header Encoding
 
 X-Bare-Headers uses Compact Header Encoding, a new encoding designed to improve header size over JSON.
 See the [specification and reference implementation](./compact-header-encoding/) for further information.
 
-Compact Header Encoding uses a dictionary of 47 IDs numbered from 0 to 46 inclusive.
+Compact Header Encoding uses a dictionary of 8930 IDs numbered from 0 to 8929 inclusive.
 The dictionaries used in requests and responses shall be assigned in [this file](./BareHeaderDictionaries.md).
-
-## Forbidden values
-
-X-Bare-Forward-Headers:
-
-`connection`, `transfer-encoding`, `host`, `connection`, `origin`, `referer`
-
-X-Bare-Pass-Headers:
-
-`vary`, `connection`, `transfer-encoding`, `access-control-allow-headers`, `access-control-allow-methods`, `access-control-expose-headers`, `access-control-max-age`, `access-control-request-headers`, `access-control-request-method`
 
 ## Bare Request Headers
 
@@ -38,13 +22,18 @@ X-Bare-Path: /index.php
 X-Bare-Headers: ; #Host5example.org %Accept#\text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
 ```
 
+Bare headers:
 - X-Bare-Port: The port of the destination. This must be a valid number and cannot be empty. An example of logic the client must do is: `const port = protocol == "http:" ? 80 : 443;`
 - X-Bare-Protocol: The protocol the server will use when creating a request. Valid values are: `http:`, `https:`
 - X-Bare-Path: The server request path.
-- X-Bare-Headers: TODO
-- **Optional:** X-Bare-Forward-Headers: A [list](#header-lists) of case-insensitive request headers to forward to the remote. For example, if the client's user agent automatically specified the `Accept` header and the client can't retrieve this header, the client should specify `Accept` as a forwarded header.
-- **Optional:** X-Bare-Pass-Headers: A [list](#header-lists) of case-insensitive headers. If these headers are present in the remote response, the values will be added to the server response.
-- **Optional:** X-Bare-Pass-Status: A [list](#header-lists) of HTTP status codes. If the remote response status code is present in this list, the server response status will be set to the remote response status.
+- X-Bare-Headers: The CHE-serialized headers to be sent to the remote.
+
+Headers forwarded to the remote:
+- Accept-Encoding
+- Accept-Language
+- If-Modified-Since
+- If-None-Match
+- Cache-Control
 
 ## Bare Response Headers
 
@@ -58,30 +47,35 @@ X-Bare-Status-text: OK
 X-Bare-Headers: ; +Content-Type1text/html
 ```
 
-- Content-Encoding: The remote body's content encoding.
-- Content-Encoding: The remote body's content length.
+Bare headers:
+- Content-Encoding: The remote body's content encoding, if any.
+- Content-Length: The remote body's content length, if any.
+- Transfer-Encoding: The remote body's transfer encoding, if any.
 - X-Bare-Status: The status code of the remote.
 - X-Bare-Status-Text: The status text of the remote.
-- X-Bare-Headers: TODO
+- X-Bare-Headers: The CHE-serialized headers sent by the remote.
 
-## Send and receive data from a remote
+Headers forwarded from the remote:
+- Content-Encoding
+- Transfer-Encoding
+- Content-Length
+- Last-Modified
+- Etag
+- Cache-Control
+
+If the remote response's status is 304 or 204, then the Bare server must respond with that status instead of 200.
+
+## Send data to and receive data from a remote
 
 | Method | Endpoint   |
 | -------- | -------------- |
 | `*`    | /          |
 
-Request Body:
+Cache: The query string parameter `cache` is passed to the HTTP request endpoint. An effective parameter value is a checksum of the protocol, host, port, and path. However, any value is accepted.
+Request headers: see [Bare Request Headers](#bare-request-headers)
+Response headers: see [Bare Response Headers](#bare-response-headers)
 
-Request Headers:
-
-See [Bare Request Headers](#bare-request-headers)
-
-Response Headers:
-
-See [Bare Response Headers](#bare-response-headers)
-
-Response Body:
-
+The request body will be sent as the request body to the remote.
 The remote's response body will be sent as the response body.
 
 ## Create a WebSocket tunnel to a remote
@@ -90,13 +84,19 @@ The remote's response body will be sent as the response body.
 | -------- | ------------- |
 | `GET`  | /         |
 
-Request Headers:
-
+Example headers:
 ```
 Upgrade: websocket
-Sec-WebSocket-Protocol: bare-v3
+Sec-WebSocket-Protocol: some-client-chosen-protocol
 ```
 
-Response Body:
+The `Sec-WebSocket-Protocol` request header, if any, is forwarded to the remote.
 
-TODO
+Handshake:
+1. The client must send a JSON-encoded object representing the remote URL and the `Cookie` header of the form `{remote: string, cookie: string | null}`.
+2. The server must either:
+    a. send a JSON-encoded object representing the `Sec-WebSocket-Protocol` and `Set-Cookie` headers of the form `{protocol: string | null, cookies: string[]}`.
+    b. close the connection upon receiving invalid data or encountering a failure.
+3. The client must close the connection upon receiving invalid data.
+4. The WebSocket connection is now open for the proxied application.
+5. Any message or closure from one connection is sent or applied respectively to the other.


### PR DESCRIPTION
Optional X-Bare- headers are no longer to be seen. Caching is mandatory. Last but not least, WebSockets are now stateless. Note that CHE uses 8930 IDs, not 47 IDs. The headers associated with these IDs have yet to be specified.